### PR TITLE
update list of contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Rufus Pollock <rufus.pollock@okfn.org>
+Gunnlaugur Þór Briem <gunnlaugur@gmail.com>
+Benoit Chesneau <bchesneau@gmail.com>
+Paul Fitzpatrick <paul.michael.fitzpatrick@gmail.com> <paulfitz@alum.mit.edu>
+Andrew Berkeley <andrew.berkeley.is@googlemail.com>
+Richard Hall <rhllrichard@gmail.com>

--- a/_data/contributors.json
+++ b/_data/contributors.json
@@ -1,0 +1,118 @@
+[
+  {
+    "name": "Rufus Pollock",
+    "commits": 179
+  },
+  {
+    "name": "Paul Fitzpatrick",
+    "commits": 38
+  },
+  {
+    "name": "Andrew Berkeley",
+    "commits": 19
+  },
+  {
+    "name": "Francis Irving",
+    "commits": 9
+  },
+  {
+    "name": "Leigh Dodds",
+    "commits": 8
+  },
+  {
+    "name": "Benoit Chesneau",
+    "commits": 7
+  },
+  {
+    "name": "Max Ogden",
+    "commits": 5
+  },
+  {
+    "name": "Paul Walsh",
+    "commits": 5
+  },
+  {
+    "name": "Gunnlaugur Þór Briem",
+    "commits": 4
+  },
+  {
+    "name": "Jeff Allen",
+    "commits": 4
+  },
+  {
+    "name": "Martin Keegan",
+    "commits": 4
+  },
+  {
+    "name": "Aaron Schumacher",
+    "commits": 2
+  },
+  {
+    "name": "Dominik Moritz",
+    "commits": 2
+  },
+  {
+    "name": "Jason Dusek",
+    "commits": 2
+  },
+  {
+    "name": "Jonas Oberg",
+    "commits": 2
+  },
+  {
+    "name": "Josh Ferguson",
+    "commits": 2
+  },
+  {
+    "name": "Tony Hirst",
+    "commits": 2
+  },
+  {
+    "name": "Tony Narlock",
+    "commits": 2
+  },
+  {
+    "name": "AJ ONeal",
+    "commits": 1
+  },
+  {
+    "name": "Bart Kastermans",
+    "commits": 1
+  },
+  {
+    "name": "Mike Chelen",
+    "commits": 1
+  },
+  {
+    "name": "Paul Mackay",
+    "commits": 1
+  },
+  {
+    "name": "Peter Desmet",
+    "commits": 1
+  },
+  {
+    "name": "Richard Hall",
+    "commits": 1
+  },
+  {
+    "name": "Stefan Urbanek",
+    "commits": 1
+  },
+  {
+    "name": "Tantek Çelik",
+    "commits": 1
+  },
+  {
+    "name": "Thordur Bjornsson",
+    "commits": 1
+  },
+  {
+    "name": "Uri Laserson",
+    "commits": 1
+  },
+  {
+    "name": "gscalise",
+    "commits": 1
+  }
+]

--- a/index.md
+++ b/index.md
@@ -62,14 +62,20 @@ where this is both feasible and needed - be that in terms of standards,
 use of HTTP and REST, browser maturity, or, in terms of ad-hoc
 development in tools that is ripe for "standardization".
 
+{% capture initial_contributors %}
 Data Protocols was started in Autumn 2011 and arose out of discussions
 with, among others, Rufus Pollock and Friedrich Lindenberg of the [Open
 Knowledge Foundation](http://okfn.org/), Francis Irving and Aidan
 McGuire of [ScraperWiki](http://scraperwiki.com/), Max Ogden (then a
 [Code for America](http://codeforamerica.com/) fellow), Chris Taggart of
 [OpenCorporates](http://opencorporates.com/), Richard Cyganiak of
-[DERI](http://www.deri.ie/) and members of the W3C GLD Working Group and
-has subsequently benefitted from input from numerous other individuals.
+[DERI](http://www.deri.ie/) and members of the W3C GLD Working Group.
+Paul Fitzpatrick of the [Data Commons Co-op](http://datacommons.coop)
+has helped out.{% endcapture %}
+
+{{ initial_contributors }}
+Other contributors include
+{% for person in site.data.contributors %}{% unless initial_contributors contains person.name] %}{% if forloop.last %}and {% endif %}{{ person.name }}{% unless forloop.last %}, {% endunless %}{% endunless %}{% endfor %}.
 
 Participate and Contribute
 ==========================


### PR DESCRIPTION
This commit:

 * Adds a mailmap to normalize the names of contributors in git's logs.
 * Adds a snapshot of people who have committed to the repository, generated from git.
 * Adds any missing people to the homepage.
 * Adds a mention of the Data Commons Co-op.

I couldn't track down contact information for "gscalise" but found everyone
else.  I'd be happy to add text on any other contributors and affiliations.