### PR TITLE
Proposal: Clarify case sensitivity around names (headers)

### DIFF
--- a/json-table-schema/index.md
+++ b/json-table-schema/index.md
@@ -143,7 +143,10 @@ have additional keys as described below:
     attribute `SHOULD` correspond to the name of field/column in the
     data file (if it has a name). As such it `SHOULD` be unique (though
     it is possible, but very bad practice, for the data file to have
-    multiple columns with the same name)
+    multiple columns with the same name). Additionally, `name` `SHOULD`
+    be considered case sensitive. In practice, case sensistivity for names
+    can be limiting in certain scenarios, so consumers `MAY` choose to ignore
+    case sensitivity for `name` values.
 -   the field descriptor Hash MAY contain any number of other attributes
 -   specific attributes that MAY be included in the Hash and whose
     meaning is defined in this spec are:


### PR DESCRIPTION
See short discussion here: https://github.com/dataprotocols/dataprotocols/issues/172

As an implementor (https://github.com/okfn/jtskit-py), I'll be adding a flag to allow users to enable/disable case sensitivity. As noted in the above discussion, it is very useful of the spec addresses this use case specifically.