### PR TITLE
[jts] Update boolean value definitions

### DIFF
--- a/json-table-schema/index.md
+++ b/json-table-schema/index.md
@@ -242,8 +242,8 @@ The type and format list is as follows:
 * **boolean**
     * In addition to primitive types, boolean values can be indicated with the
       following strings:
-        * **true**: 'yes', 'y', 'true', 't', '0'
-        * **false**: 'no', 'n', 'false', 'f', '1'
+        * **true**: 'yes', 'y', 'true', 't', '1'
+        * **false**: 'no', 'n', 'false', 'f', '0'
     * `boolean` formats:
         * **default**: any valid boolean value or string that indicates a
           boolean value. Equivalent to not declaring a format.


### PR DESCRIPTION
The definitions of true and false were inverted when compared with the norm.

Before commit, this was all true:
    '0' == true
    '1' == false

After commit, the values have been flipped:
    '0' == false
    '1' == true


Issue: https://github.com/dataprotocols/dataprotocols/issues/184
