### PR TITLE
json-table-schema: add missing commas in examples

### DIFF
--- a/json-table-schema/index.md
+++ b/json-table-schema/index.md
@@ -325,7 +325,7 @@ Here's an example:
           "name": "a"
         },
         ...
-      ]
+      ],
       "primaryKey": "a"
 
 Here's an example with an array primary key:
@@ -342,7 +342,7 @@ Here's an example with an array primary key:
           "name": "c"
         },
         ...
-      ]
+      ],
       "primaryKey": ["a", "c"]
      }
 


### PR DESCRIPTION
Examples should probably be valid JSON.