### PR TITLE
Change "licenses" to "license" in sample datapackage

### DIFF
--- a/data-packages/index.md
+++ b/data-packages/index.md
@@ -129,7 +129,7 @@ Here is an illustrative example of a datapackage JSON file:
       # general "metadata" like title, sources etc
       "name" : "a-unique-human-readable-and-url-usable-identifier",
       "title" : "A nice title",
-      "licenses" : [...],
+      "license" : "The package's license",
       "sources" : [...],
       # list of the data resources in this data package
       "resources": [


### PR DESCRIPTION
Licenses was dropped in favor of license on version 1.0.0-beta.14 (issue #214), but there the datapackage's JSON example was still using `licenses`. This PR fixes that.